### PR TITLE
snap translations to 0 before abstracting, not when extracting the value

### DIFF
--- a/src/CodeWorld/Test/AbsTypes.hs
+++ b/src/CodeWorld/Test/AbsTypes.hs
@@ -349,8 +349,8 @@ Concretize an abstract translation.
 -}
 fromPosition :: Position -> Double
 fromPosition Zero    = 0
-fromPosition (Neg d) = fuzz $ -d
-fromPosition (Pos d) = fuzz d
+fromPosition (Neg d) = -d
+fromPosition (Pos d) = d
 
 
 fuzz :: Double -> Double
@@ -361,7 +361,7 @@ fuzz a = if abs a < 0.005 then 0 else a
 Abstract a concrete translation.
 -}
 toPosition :: Double -> Position
-toPosition d
+toPosition (fuzz -> d)
   | d == 0 = Zero
   | d < 0 = Neg $ abs d
   | otherwise = Pos d


### PR DESCRIPTION
This should take care of https://git.uni-due.de/fmi/propa-aufgaben/-/work_items/68